### PR TITLE
24-inheritance - fix compilation error in derived contract

### DIFF
--- a/content/24-inheritance.md
+++ b/content/24-inheritance.md
@@ -177,7 +177,7 @@ The super keyword means "call the parent’s function." Here’s how it can be u
 
 contract Parent {
     function foo() 
-        internal 
+        public
         pure 
         virtual 
         returns (string memory) {
@@ -187,7 +187,7 @@ contract Parent {
 
 contract Child is Parent {
 
-        // we have overriden foo and made it public
+    // we have overridden foo
     function foo() 
         public 
         pure 


### PR DESCRIPTION
Increasing the visibility of a function in a derived contract from `internal` to `public` does not work in Solidity.

```solidity
contract Parent {
    function foo() 
        internal 
        pure 
        virtual 
        returns (string memory) {
            return "foo";
    }
}

contract Child is Parent {

        // we have overriden foo and made it public
    function foo() 
        public 
        pure 
        override 
        returns (string memory) {
            return super.foo();
    }
}
```

The Child contract cannot override Parent's `foo()` and change its visibility from `internal` to `public` - [`open in Remix`](https://remix.ethereum.org/#code=Ly8gU1BEWC1MaWNlbnNlLUlkZW50aWZpZXI6IE1JVApwcmFnbWEgc29saWRpdHkgXjAuOC4yODsKCmNvbnRyYWN0IFBhcmVudCB7CiAgICBmdW5jdGlvbiBmb28oKSAKICAgICAgICBpbnRlcm5hbCAKICAgICAgICBwdXJlIAogICAgICAgIHZpcnR1YWwgCiAgICAgICAgcmV0dXJucyAoc3RyaW5nIG1lbW9yeSkgewogICAgICAgICAgICByZXR1cm4gImZvbyI7CiAgICB9Cn0KCmNvbnRyYWN0IENoaWxkIGlzIFBhcmVudCB7CgogICAgICAgIC8vIHdlIGhhdmUgb3ZlcnJpZGVuIGZvbyBhbmQgbWFkZSBpdCBwdWJsaWMKICAgIGZ1bmN0aW9uIGZvbygpIAogICAgICAgIHB1YmxpYyAKICAgICAgICBwdXJlIAogICAgICAgIG92ZXJyaWRlIAogICAgICAgIHJldHVybnMgKHN0cmluZyBtZW1vcnkpIHsKICAgICAgICAgICAgcmV0dXJuIHN1cGVyLmZvbygpOwogICAgfQp9&version=soljson-v0.8.28+commit.7893614a.js&lang=en&optimize=false&runs=200&evmVersion=null
). According to the Solidity documentation [`docs.soliditylang.org`](https://docs.soliditylang.org/en/latest/contracts.html#function-overriding), when overriding functions, "The overriding function may only change the visibility of the overridden function from `external` to `public`." Since changing the Parent's `foo()` to `external` wouldn't make `foo` visible to the _super_ call, it was set it to `public` so that it could be tested in Remix.
