### PR TITLE
27-immutable-variables - use a value type instead of a string, as immutable

### DIFF
--- a/content/27-immutable-variables.md
+++ b/content/27-immutable-variables.md
@@ -6,10 +6,10 @@ If you aren’t ever going to change a variable, it’s best to explicit about y
 
 contract ExampleContract {
 
-    string immutable public name;
+    uint256 public immutable value;
 
-    constructor(string memory _name) {
-        name = _name;
+    constructor(uint256 _value) {
+        value = _value;
     }
 }
 ```
@@ -22,16 +22,16 @@ If you try to write to an immutable variable, the code will not compile.
 
 contract ExampleContract {
 
-    string immutable public name;
+    uint256 public immutable value;
 
-    constructor(string memory _name) {
-        name = _name;
+    constructor(uint256 _value) {
+        value = _value;
     }
 
     // ERROR: Cannot compile
-    function cannotChangeTheName(string calldata _newName) 
+    function cannotChangeTheName(uint256 _newValue)
             external {
-                name = _newName;
+                value = _newValue;
     }
 }
 ```


### PR DESCRIPTION
The Solidity compiler throws a type error on the contract below: "Immutable variables cannot have a non-value type." - [`open in Remix`](https://remix.ethereum.org/#code=Ly8gU1BEWC1MaWNlbnNlLUlkZW50aWZpZXI6IE1JVApwcmFnbWEgc29saWRpdHkgXjAuOC4yODsKCmNvbnRyYWN0IEV4YW1wbGVDb250cmFjdCB7CgogICAgc3RyaW5nIGltbXV0YWJsZSBwdWJsaWMgbmFtZTsKCiAgICBjb25zdHJ1Y3RvcihzdHJpbmcgbWVtb3J5IF9uYW1lKSB7CiAgICAgICAgbmFtZSA9IF9uYW1lOwogICAgfQp9&lang=en&optimize=false&runs=200&evmVersion=null&version=soljson-v0.8.28+commit.7893614a.js).


```solidity
contract ExampleContract {

    string immutable public name;

    constructor(string memory _name) {
        name = _name;
    }
}
```

This is also mentioned in the [`documentation`](https://docs.soliditylang.org/en/latest/contracts.html#constant-and-immutable-state-variables): "Not all types for constants and immutables are implemented at this time. The only supported types are strings (only for constants) and value types."

Since `string` cannot be immutable, a value type must to be used instead.
