### PR TITLE
28-constants - fix minor formatting issue and typo

### DIFF
--- a/content/28-constants.md
+++ b/content/28-constants.md
@@ -10,19 +10,19 @@ This would be the clean way to do it
 
 ```solidity
 
-**contract ExampleERC20 {
+contract ExampleERC20 {
 
     uint256 public constant MAX_SUPPLY = 22_000_000;
     // erc20 code
 
-    function mint(unint256 amount) external {
+    function mint(uint256 amount) external {
         require(totalSupply() + amount <= MAX_SUPPLY, "max supply exceeded");
         balanceOf[msg.sender] += amount;
 
         emit Transfer(address(0), msg.sender, amount);
     }
     // rest of the erc20 code
-}**
+}
 ```
 
 Note that 22000000 was written as 22_000_000. They mean the same thing, but the latter is more readable. Underscores in numbers are simply ignored.


### PR DESCRIPTION
Removed the leading and trailing ** around the contract and changed "unint256" to "uint256".